### PR TITLE
When retry fails, logs Aino JSON to the local log for recovery tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.aino.agents</groupId>
     <artifactId>AgentJava</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.groupId}.${project.artifactId}</name>
     <description>Java Agent for Aino.io</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.aino.agents</groupId>
     <artifactId>AgentJava</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>${project.groupId}.${project.artifactId}</name>
     <description>Java Agent for Aino.io</description>

--- a/src/main/java/io/aino/agents/core/DefaultApiClient.java
+++ b/src/main/java/io/aino/agents/core/DefaultApiClient.java
@@ -19,6 +19,7 @@ package io.aino.agents.core;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
+import com.sun.jersey.api.client.filter.LoggingFilter;
 import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
 import io.aino.agents.core.config.AgentConfig;
 
@@ -37,6 +38,7 @@ public class DefaultApiClient implements ApiClient {
         this.agentConfig = config;
         URLConnectionClientHandler connection = HttpProxyFactory.getConnectionHandler(agentConfig);
         Client restClient = new Client(connection);
+        restClient.addFilter(new LoggingFilter());
         resource = restClient.resource(agentConfig.getLogServiceUri());
     }
 

--- a/src/main/java/io/aino/agents/core/Sender.java
+++ b/src/main/java/io/aino/agents/core/Sender.java
@@ -140,6 +140,9 @@ public class Sender implements Runnable, TransactionDataObserver {
             ApiResponse response = client.send(getRequestContent());
 
             status.responseStatus(response);
+            if(status.retryCount ==  status.MAX_RETRIES){
+                log.error("\nAINO_ERROR_START\n"+stringToSend+"\nAINO_ERROR_END");
+            }
         } catch (ClientHandlerException e) {
             status.exceptionStatus();
         } finally {

--- a/src/main/java/io/aino/agents/core/SenderStatus.java
+++ b/src/main/java/io/aino/agents/core/SenderStatus.java
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
 class SenderStatus {
     private static final Log log = LogFactory.getLog(SenderStatus.class);
 
-    private static final int MAX_RETRIES = 4;
+    public static final int MAX_RETRIES = 4;
     boolean retryLastSend = false;
     int retryCount = 0;
 

--- a/src/main/java/io/aino/agents/core/TransactionDataBuffer.java
+++ b/src/main/java/io/aino/agents/core/TransactionDataBuffer.java
@@ -118,8 +118,12 @@ public class TransactionDataBuffer {
     }
 
     private int elementsToDrain() {
-        // ensure transactions get sent one at a time when size threshold is zero or one
-        return sizeThreshold <= 1 ? 1 : Integer.MAX_VALUE;
+        int maxDrain = 500; // Aino server can handle max 500 transaction  in one rest-call so we limit it here
+        if(sizeThreshold < maxDrain)
+            // ensure transactions get sent one at a time when size threshold is zero or one
+            return sizeThreshold <= 1 ? 1 : sizeThreshold;
+        else
+            return maxDrain;
     }
 
 }

--- a/src/main/java/io/aino/agents/core/TransactionDataBuffer.java
+++ b/src/main/java/io/aino/agents/core/TransactionDataBuffer.java
@@ -83,7 +83,6 @@ public class TransactionDataBuffer {
     public String getDataToSend() throws IOException {
         final List<TransactionSerializable> entries = new ArrayList<TransactionSerializable>();
         this.transactions.drainTo(entries, elementsToDrain());
-
         return mapper.writeValueAsString(new Object() {
             private final List<TransactionSerializable> transactions = entries;
             public List<TransactionSerializable> getTransactions() { return transactions; } // Needed for mapper?
@@ -118,7 +117,7 @@ public class TransactionDataBuffer {
     }
 
     private int elementsToDrain() {
-        int maxDrain = 500; // Aino server can handle max 500 transaction  in one rest-call so we limit it here
+        int maxDrain = 400; // Aino server can handle max 500 transaction  in one rest-call so we limit it here to the safe level
         if(sizeThreshold < maxDrain)
             // ensure transactions get sent one at a time when size threshold is zero or one
             return sizeThreshold <= 1 ? 1 : sizeThreshold;

--- a/src/test/integration/java/io/aino/agents/core/AgentIntegrationTest.java
+++ b/src/test/integration/java/io/aino/agents/core/AgentIntegrationTest.java
@@ -45,10 +45,12 @@ public class AgentIntegrationTest {
     private static final String API_URL = "http://localhost:8808/api/1.0";
     private static final String AINO_CONFIG = "validConfig.xml";
     private static final String AINO_CONFIG_WITH_LONG_INTERVAL = "validConfigWithIntervalAndSize.xml";
+    private static final String AINO_CONFIG_WITH_SIZE = "validConfigWithSize.xml";
     private static final String AINO_CONFIG_WITH_PROXY = "validConfigWithProxy.xml";
 
     private Agent ainoAgent = getAinoLogger();
     private Agent slowAinoAgent = getSlowAinoLogger();
+    private Agent limitedAinoAgent = getLimitedAinoLogger();
     private Agent proxiedAinoAgent = getProxiedAinoLogger();
 
     private static Agent getAinoLogger() {
@@ -59,6 +61,11 @@ public class AgentIntegrationTest {
     private static Agent getSlowAinoLogger() {
         Agent.LoggerFactory ainoLoggerFactory = new Agent.LoggerFactory();
         return ainoLoggerFactory.setConfigurationBuilder(new ClasspathResourceConfigBuilder(AINO_CONFIG_WITH_LONG_INTERVAL)).build();
+    }
+
+    private static Agent getLimitedAinoLogger() {
+        Agent.LoggerFactory ainoLoggerFactory = new Agent.LoggerFactory();
+        return ainoLoggerFactory.setConfigurationBuilder(new ClasspathResourceConfigBuilder(AINO_CONFIG_WITH_SIZE)).build();
     }
 
     private static Agent getProxiedAinoLogger() {
@@ -140,7 +147,8 @@ public class AgentIntegrationTest {
 
     @Test
     public void loggerSendsManyTransactionsToMockApiTest() throws Exception {
-        assertLoggerSendsManyTransactionsToMockApi(slowAinoAgent);
+        assertLoggerSendsManyTransactionsToMockApi(limitedAinoAgent);
+//        assertLoggerSendsManyTransactionsToMockApi(slowAinoAgent);
     }
 
     @Test
@@ -204,31 +212,35 @@ public class AgentIntegrationTest {
     }
 
     public void assertLoggerSendsManyTransactionsToMockApi(Agent agent) throws Exception {
-        System.out.println("agent.isenabled="+agent.isEnabled());
-        System.out.println("SIZE-TRESHOLD="+agent.getAgentConfig().getSizeThreshold());
-        initializeBatchTransaction(agent,100);
+        initializeBatchTransaction(agent,900);
 
         // wait for first send
-        Thread.sleep(1000); // :(
+        Thread.sleep(2000); // :(
         HttpMethod get = new GetMethod(API_URL + "/test/readTransactions");
         int statusCode = client.executeMethod(get);
         System.out.println("GET="+get.getResponseBodyAsString());
         JsonNode transactions = parseJsonFromResponseBody(get).findPath("transactions");
         assertNotNull("JsonNode 'transactions' should not be null", transactions);
         System.out.println("transactions.size="+transactions.size());
-        assertEquals("There should be exactly 10 transaction", 10, transactions.size());
+        assertEquals("There should be exactly 400 transaction", 400, transactions.size());
 
         // wait  until all items are sent
-        Thread.sleep(30000); // :(
+        Thread.sleep(5000); // :(
         statusCode = client.executeMethod(get);
         transactions = parseJsonFromResponseBody(get).findPath("transactions");
         assertNotNull("JsonNode 'transactions' should not be null", transactions);
-        System.out.println("transactions.size="+transactions.size());
-        assertEquals("There should be exactly 100 transaction", 100, transactions.size());
+        assertEquals("There should be exactly 900 transaction", 900, transactions.size());
 
         JsonNode operationNode = transactions.get(0).get("operation");
         assertEquals("Create", operationNode.asText());
         assertEquals(200, statusCode);
+
+        // Check last request size
+        get = new GetMethod(" http://localhost:8808/api/1.0/saveLogArray/services/operations/recorded-requests");
+        statusCode = client.executeMethod(get);
+        System.out.println(statusCode+ " - GET="+get.getResponseBodyAsString());
+
+
     }
 
     private void initializeBatchTransaction(Agent agent, int count){

--- a/src/test/integration/java/io/aino/agents/core/AgentIntegrationTest.java
+++ b/src/test/integration/java/io/aino/agents/core/AgentIntegrationTest.java
@@ -234,13 +234,6 @@ public class AgentIntegrationTest {
         JsonNode operationNode = transactions.get(0).get("operation");
         assertEquals("Create", operationNode.asText());
         assertEquals(200, statusCode);
-
-        // Check last request size
-        get = new GetMethod(" http://localhost:8808/api/1.0/saveLogArray/services/operations/recorded-requests");
-        statusCode = client.executeMethod(get);
-        System.out.println(statusCode+ " - GET="+get.getResponseBodyAsString());
-
-
     }
 
     private void initializeBatchTransaction(Agent agent, int count){

--- a/src/test/resources/validConfigWithSize.xml
+++ b/src/test/resources/validConfigWithSize.xml
@@ -1,0 +1,24 @@
+<ainoConfig>
+    <ainoLoggerService enabled="true">
+        <address uri="http://localhost:8808/api/1.0/saveLogArray" apiKey="80D0710C-2EE6-481E-BA9E-9A21C2486EE7"/>
+        <send interval="1000" sizeThreshold="1000"/>
+    </ainoLoggerService>
+    <operations>
+        <operation key="create" name="Create" />
+        <operation key="update" name="Update" />
+        <operation key="delete" name="Delete" />
+    </operations>
+    <applications>
+        <application key="esb" name="ESB" />
+        <application key="app01" name="TestApp 1"/>
+        <application key="app02" name="TestApp 2" />
+    </applications>
+    <idTypes>
+        <idType key="dataType01" name="Data Type 1" />
+        <idType key="dataType02" name="Data Type 5" />
+    </idTypes>
+    <payloadTypes>
+        <payloadType key="subInterface01" name="Interface 1" />
+        <payloadType key="subInterface02" name="Interface 2" />
+    </payloadTypes>
+</ainoConfig>


### PR DESCRIPTION
When retry fails last time, add failed JSON between AITI_RETRY_STARTS - AINO_RETRY_END tags.
Later this can be retransmitted to aino.

See example
AINO_ERROR_START
{"transactions":[{"message":"","timestamp":1524130302651,"status":"success","flowId":"","ids":[],"metadata":[],"from":"TestApp 1","to":"TestApp 2","operation":"","payloadType":""}]}
AINO_ERROR_END